### PR TITLE
Microdata format for event data

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,13 +4,14 @@
   :license {:name "The Unlicense"
             :url "http://unlicense.org/UNLICENSE"}
 
-  :dependencies [[org.clojure/clojure "1.7.0-beta3"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "0.0-3211"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [cljs-ajax "0.3.11"]
                  [sablono "0.3.4"]
                  [org.omcljs/om "0.8.8"]
-                 [prismatic/schema "0.4.3"]]
+                 [prismatic/schema "0.4.3"]
+                 [com.andrewmcveigh/cljs-time "0.3.10"]]
 
   :plugins [[lein-cljsbuild "1.0.5"]
             [lein-figwheel "0.3.3"]]
@@ -43,7 +44,7 @@
              :css-dirs ["resources/public/css"] ;; watch and update CSS
 
              ;; Start an nREPL server into the running figwheel process
-             ;; :nrepl-port 7888
+             :nrepl-port 7888
 
              ;; Server Ring Handler (optional)
              ;; if you want to embed a ring handler into the figwheel http-kit

--- a/resources/public/data/events.edn
+++ b/resources/public/data/events.edn
@@ -15,4 +15,20 @@
                   :longitude -118.464982
                   }
             :description "Sausage, beer and parens."}}
+{:context "http:/schema.org"
+ :type :event
+ :start-date "2015-05-31T19:30:00+09:00"
+ :end-date "2015-05-31T21:30:00+09:00"
+ :name "Wursklojure (Again)"
+ :image "http://static1.squarespace.com/static/53b4405ee4b09093499ff081/53b48da8e4b04ba659c1bdf7/53cd5369e4b00a460e583e20/1405965162468/wurstkuche.jpg?format=1000w"
+ :description "A most delicious example event!"
+ :location {:type :place
+            :event-status :pending
+            :name "Wurstküche"
+            :address "625 Lincoln Blvd, Venice, CA 90291"
+            :geo {:type :geo-coordinates
+                  :latitude 33.99974
+                  :longitude -118.464982
+                  }
+            :description "Sausage, beer and parens."}}
 ]

--- a/resources/public/data/events.edn
+++ b/resources/public/data/events.edn
@@ -1,13 +1,13 @@
 [
 {:context "http:/schema.org"
  :type :event
- :startDate "2015-05-30T19:30:00+09:00"
- :endDate "2015-05-30T21:30:00+09:00"
+ :start-date "2015-05-30T19:30:00+09:00"
+ :end-date "2015-05-30T21:30:00+09:00"
  :name "Wursklojure"
  :image "http://static1.squarespace.com/static/53b4405ee4b09093499ff081/53b48da8e4b04ba659c1bdf7/53cd5369e4b00a460e583e20/1405965162468/wurstkuche.jpg?format=1000w"
  :description "A most delicious example event!"
  :location {:type :place
-            :eventStatus :pending
+            :event-status :pending
             :name "Wurstküche"
             :address "625 Lincoln Blvd, Venice, CA 90291"
             :geo {:type :geo-coordinates

--- a/src/clojurecafe/core.cljs
+++ b/src/clojurecafe/core.cljs
@@ -46,9 +46,9 @@
 
 (get-events result-chan)
 
-(defn calendar-widget [events]
+(defn calendar-widget [{:keys [events] } ]
   (om/component
-   (html [:div {:id "events"}
+   (html [:ul {:id "events"}
           (for [event events]
             [:ul {:id (:type event)}
              [:li (:start-date event)]
@@ -62,14 +62,17 @@
                 [:li (:address location)]
                 [:li (:latitude  (:geo location))]
                 [:li (:longitude (:geo location))]
-                [:li (:description location)])]])
-          (html/submit-button "React!")] )))
+                [:li (:description location)])]])] )))
 
-(om/root calendar-widget (:events @app-state) {:target js/document.body})
+(om/root calendar-widget
+         ;;         (:events @app-state)
+         app-state
+         {:target js/document.body}
+         )
 
 
 (defn on-js-reload []
   ;; optionally touch your app-state to force rerendering depending on
   ;; your application
-  ;; (swap! app-state update-in [:__figwheel_counter] inc)
+  (swap! app-state update-in [:__figwheel_counter] inc)
 )

--- a/src/clojurecafe/core.cljs
+++ b/src/clojurecafe/core.cljs
@@ -48,20 +48,23 @@
 
 (defn calendar-widget [events]
   (om/component
-   (html [:div "Hello bob!"
-          [:ul (for [n (range 1 10)]
-                 [:li {:key n} n])]
-          (html/submit-button "React!")])))
+   (html [:div {:id "events"}
+          (for [event events]
+            [:ul {:id (:type event)}
+             [:li (:start-date event)]
+             [:li (:end-date event)]
+             [:li (:name event)]
+             [:ul {:id "location"}
+              (let [location (:location event)]
+                [:li (:type location)]
+                [:li (:event-status location)]
+                [:li (:name location)]
+                [:li (:address location)]
+                [:li (:latitude  (:geo location))]
+                [:li (:longitude (:geo location))]
+                [:li (:description location)])]])
+          (html/submit-button "React!")] )))
 
-;; (om/root
-;;   (fn [data owner]
-;;     (reify om/IRender
-;;       (render [_]
-;;         (dom/h1 nil (:text data)))))
-;;   app-state
-;;   {:target (. js/document (getElementById "app"))})
-
-;; just paste from sablono readme
 (om/root calendar-widget (:events @app-state) {:target js/document.body})
 
 

--- a/src/clojurecafe/core.cljs
+++ b/src/clojurecafe/core.cljs
@@ -46,7 +46,7 @@
 
 (get-events result-chan)
 
-(defn calendar-widget [{:keys [events] } ]
+(defn calendar-widget [{:keys [events]} ]
   (om/component
    (html [:ul {:id "events"}
           (for [event events]
@@ -54,6 +54,7 @@
              [:li (:start-date event)]
              [:li (:end-date event)]
              [:li (:name event)]
+             [:img {:src (:image event)}]
              [:ul {:id "location"}
               (let [location (:location event)]
                 [:li (:type location)]

--- a/src/clojurecafe/core.cljs
+++ b/src/clojurecafe/core.cljs
@@ -30,7 +30,7 @@
 (defn error-handler [{:keys [status status-text]}]
   (log "Error: " status " " status-text))
 
-(defn load-events [result-chan]
+(defn get-events [result-chan]
   (ajax/GET
     "/data/events.edn"
     {:handler (fn [res] (go (>! result-chan {:success? true :data res})))
@@ -44,7 +44,7 @@
           {:keys [success? data]} result]
       (if success? (success-handler data) (error-handler data)))))
 
-(load-events result-chan)
+(get-events result-chan)
 
 (defn calendar-widget [events]
   (om/component

--- a/src/clojurecafe/schema.cljc
+++ b/src/clojurecafe/schema.cljc
@@ -39,13 +39,13 @@
   "Schema for a meetup event."
   {:context  Url
    :type (s/enum :event)
-   :startDate ISO-Date-Time
-   :endDate ISO-Date-Time
+   :start-date ISO-Date-Time
+   :end-date ISO-Date-Time
    :name s/Str
    :image Url
    :description s/Str
    :location {:type (s/enum :place :postal-address)
-              :eventStatus (s/enum :confirmed :pending :suggestion)
+              :event-status (s/enum :confirmed :pending :suggestion)
               :name s/Str 
               :address s/Str
               (s/optional-key :geo) {:type (s/enum :geo-coordinates :geo-shape) ;;http://schema.org/GeoCoordinates


### PR DESCRIPTION
I wanted to show a microdata format for the event data, just to start something. I also added the dependency to cljs-time, and used inline css to shrink images a bit.

Moving forward, the microdata should be output of a function bashing on the event data structure. This needs some thought.
![screenshot 2015-07-09 07 43 47](https://cloud.githubusercontent.com/assets/537357/8598209/609946a4-260e-11e5-8d9c-59a6e52e6a21.png)
